### PR TITLE
Adds date parsing for stats

### DIFF
--- a/lib/overwatch.js
+++ b/lib/overwatch.js
@@ -21,6 +21,21 @@ const PLATFORMS = {
     PC : "pc"
 }
 
+const parseDate = function(str) {
+    if (str.indexOf(':') > 0) {
+        let intervals = str.split(':').reverse();
+        intervals.at0 = (idx) => intervals[idx] || 0;
+        // UTC date gives us milliseconds since the unix epoch
+        return Date.UTC(1970, 0, intervals.at0(3) + 1, intervals.at0(2), intervals.at0(1), intervals.at0(0));
+    }
+    if (str.endsWith('s')) str = str.substr(0, str.length - 1); // remove trailing s
+    if (str.endsWith("second")) return parseInt(str) * 1000;
+    if (str.endsWith("minute")) return parseInt(str) * 60000;
+    if (str.endsWith("hour"))   return parseInt(str) * 3600000;
+    if (str.endsWith("day"))    return parseInt(str) * 86400000;
+    return parseInt(str);
+}
+
 let OverwatchProvider = function() {
     var self = this;
 
@@ -29,7 +44,9 @@ let OverwatchProvider = function() {
     }
 
     String.prototype.cast = function() {
-        return  this.indexOf('.') > 0 ? parseFloat(this) : parseInt(this.replace(/,/g,''));
+        if (this.indexOf('.') > 0) return parseFloat(this);
+        if (this.indexOf(':') > 0 || this.split(' ').length > 1) return parseDate(this);
+        return parseInt(this.replace(/,/g,''));
     }
 
     let getUrl = (platform, region, tag) => {


### PR DESCRIPTION
This fixes objective time, time on fire, etc. getting parsed as the greatest interval, as well as hero play time getting parsed as the number of seconds/minutes/hours (excluding the unit). Times will now be parsed as a millisecond duration, allowing them to be used with dates and moment.